### PR TITLE
Changes for Nomad Workload Identity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
 
     nomad = {
       source  = "hashicorp/nomad"
-      version = "2.0.0-beta.1"
+      version = "~> 2.3"
     }
 
     consul = {

--- a/main.tf
+++ b/main.tf
@@ -201,7 +201,7 @@ resource "vault_policy" "frontend" {
 }
 
 resource "vault_jwt_auth_backend_role" "frontend_role" {
-  backend        = vault_jwt_auth_backend.nomad.path
+  backend        = "nomad"
   role_name      = "${var.stack_id}-frontend"
   token_policies = ["${var.stack_id}-frontend"]
 

--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,7 @@ resource "vault_database_secret_backend_role" "mongodb" {
 data "vault_policy_document" "frontend" {
   rule {
     path         = "${var.stack_id}-mongodb/creds/demo"
-    capabilities = ["read"]
+    capabilities = ["read", "update"]
   }
 }
 
@@ -305,3 +305,5 @@ resource "consul_intention" "example" {
   destination_name = data.consul_service.mongo_service.name
   action           = "allow"
 } 
+
+# Warning: The consul_intention resource is deprecated in favor of the consul_config_entry resource. Please see https://registry.terraform.io/providers/hashicorp/consul/latest/docs/guides/upgrading#upgrading-to-2110 on instructions to upgrade.

--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,7 @@ resource "vault_database_secret_backend_role" "mongodb" {
 data "vault_policy_document" "frontend" {
   rule {
     path         = "${var.stack_id}-mongodb/creds/demo"
-    capabilities = ["read", "update"]
+    capabilities = ["read"]
   }
 }
 
@@ -273,8 +273,9 @@ job "${var.stack_id}-frontend" {
         task "${var.stack_id}-frontend" {
             driver = "docker"
             vault {
-                change_mode   = "restart"
-                role = "${var.stack_id}-frontend"
+                change_mode = "restart"
+                namespace   = "admin"
+                role        = "${var.stack_id}-frontend"
             }
             template {
                 data = <<EOH

--- a/main.tf
+++ b/main.tf
@@ -299,12 +299,18 @@ data "consul_service" "frontend_service" {
   name       = "${var.stack_id}-frontend"
 }
 
-resource "consul_intention" "example" {
+resource "consul_config_entry" "database" {
   count = var.create_consul_intention ? 1 : 0
 
-  source_name      = data.consul_service.frontend_service.name
-  destination_name = data.consul_service.mongo_service.name
-  action           = "allow"
-} 
+  name = data.consul_service.mongo_service.name
+  kind = "service-intentions"
 
-# Warning: The consul_intention resource is deprecated in favor of the consul_config_entry resource. Please see https://registry.terraform.io/providers/hashicorp/consul/latest/docs/guides/upgrading#upgrading-to-2110 on instructions to upgrade.
+  config_json = jsonencode({
+    Sources = [{
+      Action     = "allow"
+      Name       = data.consul_service.frontend_service.name
+      Precedence = 9
+      Type       = "consul"
+    }]
+  })
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "stack_id" {
 }
 
 variable "tfc_organization" {
-  type    = string
+  type        = string
   description = "The TFCB organization to use"
 }
 
@@ -14,16 +14,16 @@ variable "region" {
 }
 
 variable "frontend_app_image" {
-  type = string
+  type        = string
   description = "Frontend app image to deploy"
 }
 
 variable "mongodb_image" {
-  type = string
+  type        = string
   description = "MongoDB image to deploy"
 }
 
 variable "create_consul_intention" {
-  type = bool
+  type        = bool
   description = "Allow the frontend to communicate with the backend (MongoDB)"
 }


### PR DESCRIPTION
1. Updated the Nomad Vault integration to use Workload Identity instead of token role. Workload Identity was introduced in Nomad 1.7. ([Blog](https://www.hashicorp.com/blog/nomad-1-7-improves-vault-and-consul-integrations-adds-numa-support))

2. Also ran `terraform fmt`

Correlated with [PR 5](https://github.com/djschnei21/multi-product-integration-demo/pull/5)